### PR TITLE
Add a caution about using Chromium with webfonts

### DIFF
--- a/docs/customize/fonts.md
+++ b/docs/customize/fonts.md
@@ -38,7 +38,9 @@ FROM gotenberg/gotenberg:7
 
 USER root
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends my-fonts-package
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && apt-get install -y -qq --no-install-recommends my-fonts-package \
+    && apt-get clean
 
 USER gotenberg
 ```

--- a/docs/modules/chromium.mdx
+++ b/docs/modules/chromium.mdx
@@ -402,6 +402,13 @@ Check the available PDF formats:
 </TabItem>
 </Tabs>
 
+:::caution
+
+Using webfonts in the template significantly increases the PDF file size. When using a custom font, see the
+[Fonts](../customize/fonts) chapter on how to install them in the Docker container instead.
+
+:::
+
 ### URL
 
 `POST /forms/chromium/convert/url`


### PR DESCRIPTION
I completely missed the `customize/fonts` page when reading the documentation, but as discovered in https://github.com/gotenberg/gotenberg/issues/521 the impact of webfonts can be quite big. I propose to add a little mention of this in the Chromium article.

Also, I updated the Docker example a bit to include `apt-get clean`, which reduces final image size by reducing the size of the layer.