### PR TITLE
[doc] Fix a typo in webhook.mdx

### DIFF
--- a/docs/webhook.mdx
+++ b/docs/webhook.mdx
@@ -95,7 +95,7 @@ Body: Invalid '{header_key}' header value: '{url}' does not match the authorized
 <TabItem value="callback">
 
 ```
-Content-Disposition: attachement; filename={output-filename.ext}
+Content-Disposition: attachment; filename={output-filename.ext}
 Content-Type: {content-type}
 Content-Length: {content-length}
 Gotenberg-Trace: {trace}


### PR DESCRIPTION
(Sorry about the formatting, GitHub's "pen edit".)