### PR TITLE
Add request method to webhook-download.mdx

### DIFF
--- a/docs/webhook-download.mdx
+++ b/docs/webhook-download.mdx
@@ -136,6 +136,8 @@ User-Agent: Gotenberg
 
 Set the `Gotenberg-Webhook-Events-Url` header to receive structured JSON events after each webhook operation. Events fire after the main webhook callbacks and do not affect the result delivery.
 
+They are send with POST Http Method and contain the following json contents:
+
 **Success event:**
 
 ```json


### PR DESCRIPTION
Hey,
I had a long testing session to find that the method for the Event URL is POST. Yes, in retrospect it is obvious, but I hope with  the clearer documentation s.b. else might see it earlier.